### PR TITLE
lib: Create simple block watcher without blockstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -314,7 +314,6 @@ develop-eggs/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const ethers = require("ethers");
 const BlockWatcher = require("./lib/blockWatcher");
 const RoundInitializer = require("./lib/roundInitializer");
 const TxSigner = require("./lib/txSigner");
+const SimpleBlockWatcher = require("./lib/simpleBlockWatcher");
 
 const ROUNDS_MANAGER_ADDRESSES = {
   1: ["0x3984fc4ceeef1739135476f625d36d6c35c40dc3"],
@@ -23,9 +24,9 @@ const ROUNDS_MANAGER_ADDRESSES = {
 
 const argv = require("yargs")
   .usage(
-    "Usage: $0 --rinkeby --provider [provider URL] --account [Ethereum account] --password [Ethereum account password] --datadir [data directory] --roundsManagerAddr [RoundsManager addresses]"
+    "Usage: $0 --rinkeby --provider [provider URL] --account [Ethereum account] --password [Ethereum account password] --datadir [data directory] --roundsManagerAddr [RoundsManager addresses] --pollingInterval [block polling interval in ms] --noBlockstream"
   )
-  .boolean(["rinkeby"])
+  .boolean(["rinkeby", "noBlockstream"])
   .string(["provider", "account", "roundsManagerAddr", "password"])
   .default("roundsManagerAddr", "")
   .demandOption(["account", "datadir"])
@@ -58,7 +59,9 @@ const run = async () => {
     roundsManagerAddrs = ROUNDS_MANAGER_ADDRESSES[network.chainId];
   }
 
-  const blockWatcher = new BlockWatcher(provider);
+  const blockWatcher = argv.noBlockstream
+    ? new SimpleBlockWatcher(provider, argv.pollingInterval)
+    : new BlockWatcher(provider, argv.pollingInterval);
   const roundInitializer = new RoundInitializer(
     provider,
     roundsManagerAddrs,

--- a/lib/blockWatcher.js
+++ b/lib/blockWatcher.js
@@ -8,7 +8,7 @@ module.exports = class BlockWatcher {
         pollingInterval
     ) {
         this.provider = provider
-        this.pollingInterval = pollingInterval === undefined ? DEFAULT_POLLING_INTERVAL_MS : pollingInterval
+        this.pollingInterval = pollingInterval || DEFAULT_POLLING_INTERVAL_MS
         this.blockAndLogStreamer = undefined
         this.onBlockAddedSubscriptionToken = undefined
         this.blockAndLogStreamerIntervalId = undefined

--- a/lib/simpleBlockWatcher.js
+++ b/lib/simpleBlockWatcher.js
@@ -1,0 +1,64 @@
+const DEFAULT_POLLING_INTERVAL_MS = 13000
+
+/**
+ * Block watcher that just fetches the last block and triggers the callback if it changed. This is opposed to the
+ * blockstream implementation that fetches all blocks since the previous one. This is needed for some testnet providers
+ * that throttle their API response times, making the default blockstreamer not keep up with all blocks produced.
+ */
+module.exports = class SimpleBlockWatcher {
+    constructor(
+        provider,
+        pollingInterval
+    ) {
+        this.provider = provider
+        this.pollingInterval = pollingInterval || DEFAULT_POLLING_INTERVAL_MS
+
+        this.lastBlockNumber = undefined
+        this.intervalId = undefined
+    }
+
+    subscribe(cb) {
+        this.intervalId = this.setIntervalAsyncFn(async () => {
+            const latestBlock = await this.provider.getBlock("latest")
+
+            if (!this.lastBlockNumber || latestBlock.number > this.lastBlockNumber) {
+                this.lastBlockNumber = latestBlock.number
+
+                await cb(latestBlock)
+            }
+        }, this.pollingInterval, this.onError.bind(this))
+    }
+
+    unsubscribe() {
+        this.clearIntervalAsyncFn(this.intervalId)
+    }
+
+    onError(err) {
+        console.warn("Block watcher error:", err)
+    }
+
+    // Utilities
+
+    setIntervalAsyncFn(fn, intervalMs, onError) {
+        let isRunning = false
+        const intervalId = setInterval(async () => {
+            if (isRunning) {
+                return
+            } else {
+                isRunning = true
+                try {
+                    await fn()
+                } catch (err) {
+                    onError(err)
+                }
+                isRunning = false
+            }
+        }, intervalMs)
+
+        return intervalId
+    }
+
+    clearIntervalAsyncFn(intervalId) {
+        clearInterval(intervalId)
+    }
+}


### PR DESCRIPTION
When running this against Arbitrum Goerli, the blockstream cannot really keep up with all the blocks
being generated by Arbitrum.

So what happens is that each iteration gets longer and longer, taking up to 20 hours to reconcile blocks
after leaving it running for a couple days (meaning: no rounds initialized for that period).

This creates a simpler version of the block streamer which doesn't stream blocks at all, it just fetches the
latest and calls the callback if it changed. This is all that the `roundInitializer` actually needs, since the
callback just gets the latest block anyway and only uses the number from it.